### PR TITLE
NOKI flag not being removed from room upon mob moving rooms or mob death

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -2126,9 +2126,9 @@ int char_from_room(CHAR_DATA *ch, bool stop_all_fighting) {
 			REMOVE_BIT(world[ch->in_room].room_flags, NO_TRACK);
 		}
 	if (IS_NPC(ch))
-		if (ISSET(ch->mobdata->actflags, ACT_NOKI) && !kimore && IS_SET(world[ch->in_room].iFlags, NO_TRACK)) {
-			REMOVE_BIT(world[ch->in_room].iFlags, NO_TRACK);
-			REMOVE_BIT(world[ch->in_room].room_flags, NO_TRACK);
+		if (ISSET(ch->mobdata->actflags, ACT_NOKI) && !kimore && IS_SET(world[ch->in_room].iFlags, NOKI)) {
+			REMOVE_BIT(world[ch->in_room].iFlags, NOKI);
+			REMOVE_BIT(world[ch->in_room].room_flags, NOKI);
 		}
 	if (IS_NPC(ch) && ISSET(ch->mobdata->actflags, ACT_NOMAGIC) && !Other && IS_SET(world[ch->in_room].iFlags, NO_MAGIC)) {
 		REMOVE_BIT(world[ch->in_room].iFlags, NO_MAGIC);

--- a/src/obj_proc.cpp
+++ b/src/obj_proc.cpp
@@ -2304,7 +2304,7 @@ int szrildor_pass(struct char_data *ch, struct obj_data *obj, int cmd, char *arg
                                 extract_obj(p); // extract handles all variations of obj_from_char etc
 
                 	        act("As your pass expires and crumbles to dust, you begin to feel a bit fuzzy for a moment, then vanish into thin air", v, 0,0, TO_CHAR, 0);
-       		                 act("begins to look blurry for a moment, then winks out of existence with a \"pop\"!", v, 0,0, TO_ROOM, 0);
+       		                 act("$n begins to look blurry for a moment, then winks out of existence with a \"pop\"!", v, 0,0, TO_ROOM, 0);
        		                 move_char(v, real_room(30000));
 				struct mprog_throw_type * throwitem = NULL;
 				throwitem = (struct mprog_throw_type *)dc_alloc(1, sizeof(struct mprog_throw_type));


### PR DESCRIPTION
Fixed so that NOKI flag should now be removed when mob moves rooms or dies.