### PR TITLE
Fix familiar combat-join timing/toggle and clone_mobile crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ vaults/vaultindex
 gcm.cache/
 _deps/
 .cache/
+
+# Local dev tooling (not part of the project)
+CLAUDE.md
+Dockerfile.dev
+Dockerfile.dev.dockerignore

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -3304,7 +3304,7 @@ Character *DC::clone_mobile(int nr)
 
   mob->mobdata = new Mobile;
 
-  mob->mobdata = old->mobdata;
+  *mob->mobdata = *old->mobdata;
 
   for (i = 0; i < MAX_WEAR; i++) /* Initialisering Ok */
     mob->equipment[i] = 0;

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -263,7 +263,7 @@ void perform_violence(void)
         for (fol = ch->followers; fol; fol = folnext)
         {
           folnext = fol->next;
-          if (IS_AFFECTED(fol->follower, AFF_CHARM) && ch->in_room == fol->follower->in_room)
+          if ((IS_AFFECTED(fol->follower, AFF_CHARM) || IS_AFFECTED(fol->follower, AFF_FAMILIAR)) && ch->in_room == fol->follower->in_room)
             retval = check_charmiejoin(fol->follower);
           if (isSet(retval, ReturnValue::eVICT_DIED))
             break;
@@ -2848,7 +2848,7 @@ int damage(Character *ch, Character *victim, int dam, int weapon_type, int attac
           for (fol = ch->followers; fol; fol = folnext)
           {
             folnext = fol->next;
-            if (IS_AFFECTED(fol->follower, AFF_CHARM) && ch->in_room == fol->follower->in_room)
+            if ((IS_AFFECTED(fol->follower, AFF_CHARM) || IS_AFFECTED(fol->follower, AFF_FAMILIAR)) && ch->in_room == fol->follower->in_room)
               SET_BIT(retval, check_charmiejoin(fol->follower));
             if (isSet(retval, ReturnValue::eVICT_DIED))
               break;

--- a/src/mob_proc.cpp
+++ b/src/mob_proc.cpp
@@ -3323,7 +3323,8 @@ int mage_golem(Character *ch, class Object *obj, cmd_t cmd,
   if (cmd != cmd_t::UNDEFINED || !ch->master || ch->fighting || ch->in_room != ch->master->in_room)
     return ReturnValue::eFAILURE;
 
-  if (ch->master->fighting && ch->master->fighting->isNonPlayer())
+  if (ch->master->fighting && ch->master->fighting->isNonPlayer() &&
+      ch->master->isPlayer() && isSet(ch->master->player->toggles, Player::PLR_CHARMIEJOIN))
     ch->do_join(ch->master->getName().split(' '));
 
   return ReturnValue::eFAILURE;
@@ -3379,7 +3380,7 @@ int mage_familiar_gremlin_non(Character *ch, class Object *obj,
       return ReturnValue::eFAILURE;
     }
 
-    if (ch->master->fighting)
+    if (ch->master->fighting && ch->master->isPlayer() && isSet(ch->master->player->toggles, Player::PLR_CHARMIEJOIN))
     { // help him!
       ch->do_join(ch->master->getName().split(' '));
       return ReturnValue::eFAILURE;
@@ -3437,7 +3438,7 @@ int mage_familiar_imp_non(Character *ch, class Object *obj, cmd_t cmd, const cha
       return ReturnValue::eFAILURE;
     }
 
-    if (ch->master->fighting)
+    if (ch->master->fighting && ch->master->isPlayer() && isSet(ch->master->player->toggles, Player::PLR_CHARMIEJOIN))
     { // help him!
       ch->do_join(ch->master->getName().split(' '));
       return ReturnValue::eFAILURE;
@@ -3525,7 +3526,7 @@ int druid_familiar_owl_non(Character *ch, class Object *obj, cmd_t cmd, const ch
         return ReturnValue::eFAILURE;
       }
 
-      if (ch->master->fighting)
+      if (ch->master->fighting && ch->master->isPlayer() && isSet(ch->master->player->toggles, Player::PLR_CHARMIEJOIN))
       { // help him!
         ch->do_join(ch->master->getName().split(' '));
         return ReturnValue::eFAILURE;
@@ -3571,7 +3572,7 @@ int druid_familiar_chipmunk_non(Character *ch, class Object *obj, cmd_t cmd, con
       return ReturnValue::eFAILURE;
     }
 
-    if (ch->master->fighting)
+    if (ch->master->fighting && ch->master->isPlayer() && isSet(ch->master->player->toggles, Player::PLR_CHARMIEJOIN))
     { // help him!
       ch->do_join(ch->master->getName().split(' '));
       return ReturnValue::eFAILURE;


### PR DESCRIPTION
Familiars (imp/gremlin/chipmunk/owl) now join their master's fight on the first round like golems, and honor the charmiejoin toggle:
- fight.cpp: include AFF_FAMILIAR in the two PLR_CHARMIEJOIN immediate-join gates (perform_violence and the attack path). Previously AFF_CHARM-only, so familiars were skipped and only joined a round later via the mob pulse.
- mob_proc.cpp: gate the pet auto-join procs (mage_golem and the four familiar *_non procs) on the master's PLR_CHARMIEJOIN toggle, so the toggle governs all pets instead of being bypassed by the procs.

Also fix a clone_mobile use-after-free crash (regression from ff32dcd7):
- db.cpp: clone_mobile aliased the template's mobdata (mob->mobdata = old->mobdata) right after allocating a new Mobile, so freeing one cloned mob deleted the shared mobdata and dangled every other instance, segfaulting in mobile_activity on the next pulse. Restore the deep copy (*mob->mobdata = *old->mobdata).

Add CLAUDE.md guidance and a Dockerfile.dev dev image (builds the local working tree and runs testDC, normalizing CRLF for Windows checkouts) for local build/test.