### PR TITLE
Fix fireball recombine ignoring the elemental filter

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -558,9 +558,30 @@ int spell_fireball(uint8_t level, Character *ch, Character *victim, class Object
   if (skill > 80)
     if (number(0, 100) < (skill / 5))
     {
-      act("The expanding $B$4flames$R suddenly recombine and fly at $N again!", ch, 0, victim, TO_ROOM, 0);
-      act("The expanding $B$4flames$R suddenly recombine and fly at $N again!", ch, 0, victim, TO_CHAR, 0);
-      retval = damage(ch, victim, dam, TYPE_FIRE, SPELL_FIREBALL);
+      // Follow the elemental filter (encoded in level > 200) for both the
+      // damage type and the flavor text, instead of always saying "flames".
+      int dtype = (level > 200) ? (TYPE_HIT + level - 200) : TYPE_FIRE;
+      QString element;
+      switch (dtype)
+      {
+      case TYPE_COLD:
+        element = QStringLiteral("$B$3shards of ice$R");
+        break;
+      case TYPE_ENERGY:
+        element = QStringLiteral("$B$5crackling energy$R");
+        break;
+      case TYPE_MAGIC:
+        element = QStringLiteral("$B$7burst of magic$R");
+        break;
+      case TYPE_FIRE:
+      default:
+        element = QStringLiteral("$B$4flames$R");
+        break;
+      }
+      QString recombine = QStringLiteral("The expanding %1 suddenly recombine and fly at $N again!").arg(element);
+      act(recombine, ch, 0, victim, TO_ROOM, 0);
+      act(recombine, ch, 0, victim, TO_CHAR, 0);
+      retval = damage(ch, victim, dam, dtype, SPELL_FIREBALL);
     }
   return retval;
 }


### PR DESCRIPTION
Fixes: #269
The Fireball Recombining Effect (the duplicate second blast at high fireball skill) always dealt TYPE_FIRE and printed "flames", ignoring any Elemental Filter the caster applied. The first hit honored the filter (the type is encoded in level > 200), but the recombine did not, so a fireball filtered to cold/energy/magic reverted to fire on its second hit.

Derive the damage type from level once and use it for both the damage() call and the flavor text, matching how spell_magic_missile and spell_chill_touch already filter every hit.