### PR TITLE
Fix addHP clamping to max_hit instead of hit_limit

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -2031,9 +2031,9 @@ void Character::fillHPLimit(void)
 void Character::addHP(int newhp, Character *causer)
 {
   hit += newhp;
-  if (hit > max_hit)
+  if (hit > hit_limit(this))
   {
-    hit = max_hit;
+    hit = hit_limit(this);
   }
 }
 


### PR DESCRIPTION
#272 
Character::addHP clamped HP to max_hit, but a player's real ceiling is hit_limit (max_hit + an age bonus), which is what regen (limits.cpp) and fillHPLimit already fill to. Because of the mismatch, any heal or leech that routed through addHP while the player was at full HP snapped them back down to max_hit, costing them the age-bonus HP -- e.g. casting power heal, heal, or life leech at full HP would silently remove a few points. It also meant heals could never refill a player into the age-bonus band.

Clamp to hit_limit(this) instead. NPCs are unaffected (hit_limit == max_hit for non-players); players now top out at their true maximum.