### PR TITLE
Fix cross-room melee retaliation from fired-arrow weapon procs (#274)

### DIFF
--- a/src/cl_ranger.cpp
+++ b/src/cl_ranger.cpp
@@ -1592,7 +1592,9 @@ int do_fire(Character *ch, char *arg, cmd_t cmd)
         ch->sendln("Error moving you to room in do_fire.");
         return ReturnValue::eFAILURE;
       }
+      ch->firing_arrow = true;
       retval = weapon_spells(ch, victim, ITEM_MISSILE);
+      ch->firing_arrow = false;
       // just in case
       if (isSet(retval, ReturnValue::eCH_DIED))
       {

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -567,6 +567,9 @@ int attack(Character *ch, Character *vict, int type, int weapon)
   if (!can_be_attacked(ch, vict))
     return ReturnValue::eFAILURE;
 
+  if (vict->firing_arrow)
+    return ReturnValue::eFAILURE;
+
   // TODO - until I can make sure that area effects don't attack other mobs
   // when cast by mobs, I need to make sure mobs aren't killing each other
   if (ch->isNonPlayer() && vict->isNonPlayer() &&
@@ -1469,6 +1472,8 @@ int one_hit(Character *ch, Character *vict, int type, int weapon)
   // TODO - I'd like to remove these 3 cause they are checked in attack()
   /* This happens with multi-attacks */
   if (ch->in_room != vict->in_room)
+    return ReturnValue::eFAILURE;
+  if (vict->firing_arrow)
     return ReturnValue::eFAILURE;
   if (!can_be_attacked(ch, vict))
     return ReturnValue::eFAILURE;

--- a/src/include/DC/character.h
+++ b/src/include/DC/character.h
@@ -896,6 +896,7 @@ public:
 
   int32_t timer = {};           // Timer for update
   int32_t shotsthisround = {};  // Arrows fired this round
+  bool firing_arrow = {};       // Mid weapon_spells of a fired arrow; cannot be melee'd
   int32_t spellcraftglyph = {}; // Used for spellcraft glyphs
   bool changeLeadBonus = {};
   int32_t curLeadBonus = {};


### PR DESCRIPTION
Firing an arrow with a retaliating weapon proc (poison, blindness, sleep, fear, paralyze, dispel magic, energy drain, souldrain) at a mob in an adjacent room let the mob land a melee swing on the archer even though it could not reach them -- and even when the proc was resisted.

do_fire teleports the archer into the target's room so weapon_spells can run (area procs such as earthquake/colour spray/howl need the caster co-located to hit the target's room). While co-located, the proc spells' "an eye for an eye" attack(victim, ch) retaliation passes the same-room guards in attack()/one_hit() and the swing connects; the archer is then moved back and perform_violence only clears the lingering cross-room fight a pulse later, after the hit already landed.

Mark the archer as DC::ranged_firer for the duration of the missile weapon_spells call and have attack()/one_hit() refuse to strike the ranged_firer. The teleport is kept so area procs still affect the target's room; only the bogus retaliation swing is suppressed -- the proc effect itself (poison, blindness, etc.) still applies.