### PR TITLE
Fix clan-area collection gold vanishing (QMap::value copy) (#276)

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -2293,7 +2293,7 @@ int char_from_room(Character *ch, bool stop_all_fighting)
       kimore = true;
   }
   if (ch->isPlayer()) // player
-    DC::getInstance()->zones.value(DC::getInstance()->world[ch->in_room].zone).decrementPlayers();
+    DC::getInstance()->zones[DC::getInstance()->world[ch->in_room].zone].decrementPlayers();
   if (ch->isNonPlayer())
     ch->mobdata->last_room = ch->in_room;
   if (ch->isNonPlayer())
@@ -2400,7 +2400,7 @@ int char_to_room(Character *ch, room_t room, bool stop_all_fighting)
       }
   }
   if (ch->isPlayer()) // player
-    DC::getInstance()->zones.value(DC::getInstance()->world[room].zone).incrementPlayers();
+    DC::getInstance()->zones[DC::getInstance()->world[room].zone].incrementPlayers();
   if (ch->isNonPlayer())
   {
     if (ISSET(ch->mobdata->actflags, ACT_NOMAGIC) && !isSet(DC::getInstance()->world[room].room_flags, NO_MAGIC))

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -195,12 +195,11 @@ void get(Character *ch, class Object *obj_object, class Object *sub_object, bool
     {
       int cgold = (int)((float)(obj_object->obj_flags.value[0]) * 0.1);
       obj_object->obj_flags.value[0] -= cgold;
-      DC::getInstance()->zones.value(DC::getInstance()->world[ch->in_room].zone).addGold(cgold);
+      DC::getInstance()->zones[DC::getInstance()->world[ch->in_room].zone].addGold(cgold);
       if (!ch->isNonPlayer() && isSet(ch->player->toggles, Player::PLR_BRIEF))
       {
         tax = true;
         buffer += QStringLiteral("Bounty: %2").arg(cgold);
-        DC::getInstance()->zones.value(DC::getInstance()->world[ch->in_room].zone).addGold(cgold);
       }
       else
         ch->sendln(QStringLiteral("Clan %1 collects %2 bounty, leaving %3 for you.").arg(get_clan(DC::getInstance()->zones.value(DC::getInstance()->world[ch->in_room].zone).clanowner)->name).arg(cgold).arg(obj_object->obj_flags.value[0]));
@@ -2720,7 +2719,7 @@ int palm(Character *ch, class Object *obj_object, class Object *sub_object, bool
       obj_object->obj_flags.value[0] -= cgold;
       csendf(ch, "Clan %s collects %d bounty, leaving %d for you.\r\n", get_clan(DC::getInstance()->zones.value(DC::getInstance()->world[ch->in_room].zone).clanowner)->name, cgold,
              obj_object->obj_flags.value[0]);
-      DC::getInstance()->zones.value(DC::getInstance()->world[ch->in_room].zone).addGold(cgold);
+      DC::getInstance()->zones[DC::getInstance()->world[ch->in_room].zone].addGold(cgold);
     }
 
     ch->addGold(obj_object->obj_flags.value[0]);


### PR DESCRIPTION
Depositing clan-area "bounty" gold used QMap::value(), which returns a copy of the Zone; addGold() then mutated the throwaway copy, so zone.gold never accumulated and `clans area collect` always reported no gold. The 10% taken from non-owning players who loot gold in a claimed area was destroyed rather than banked into the area's pot.

Add a guarded DC::addZoneClanGold() helper (mirroring setZoneClanGold) and route both deposit sites through it. Drop the duplicate deposit on the PLR_BRIEF branch, which added the bounty a second time. Also fix the same value()-copy mistake for zone player-counts in char_from_room / char_to_room, which left Zone::players stuck at 0 (read by a couple of object procs).

**Not able to fully test fix, so this PR should be tested on the main testing branch (that has clans, zones, etc) before going to production.**