### PR TITLE
Send charmies home after they break charm (#126)

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -1671,6 +1671,9 @@ void affect_to_char(Character *ch, affected_type *af, int32_t duration_type)
   ch->affected = affected_alloc;
 
   affect_modify(ch, af->location, af->modifier, af->bitvector, true);
+
+  if ((af->bitvector & AFF_CHARM) && ch->isNonPlayer() && ch->mobdata)
+    ch->mobdata->return_home_timer = 0;
 }
 
 /* Remove an affected_type structure from a char (called when duration
@@ -1953,6 +1956,8 @@ void affect_remove(Character *ch, affected_type *af, int flags)
         ch->add_memory(ch->master->getName(), 'h');
       stop_follower(ch, follower_reasons_t::BROKE_CHARM);
     }
+    if (!(flags & SUPPRESS_CONSEQUENCES) && ch->isNonPlayer() && ch->mobdata && !IS_AFFECTED(ch, AFF_GOLEM))
+      ch->mobdata->return_home_timer = DC::PULSES_TO_RETURN_HOME;
     break;
   case SKILL_TACTICS:
     if (!(flags & SUPPRESS_MESSAGES))

--- a/src/include/DC/DC.h
+++ b/src/include/DC/DC.h
@@ -409,6 +409,7 @@ public:
   static constexpr quint64 PULSE_TIME = 60 * PASSES_PER_SEC;
   static constexpr quint64 PULSE_REGEN = 15 * PASSES_PER_SEC;
   static constexpr quint64 PULSE_SHORT = 1; // Pulses all the time.
+  static constexpr int16_t PULSES_TO_RETURN_HOME = (10 * 60 * PASSES_PER_SEC) / PULSE_MOBILE;
   static constexpr level_t MAX_MORTAL_LEVEL = 60ULL;
   static constexpr quint64 PER_IP_CONNECTION_LIMIT = 20;
   static const QString HINTS_FILE_NAME;

--- a/src/include/DC/character.h
+++ b/src/include/DC/character.h
@@ -528,6 +528,7 @@ public:
   int16_t mpactnum = {};         // num
   int32_t last_room = {};        // Room rnum the mob was last in. Used
                                  // For !magic,!track changing flags.
+  int16_t return_home_timer = {}; // Mobile pulses until a mob that broke charm heads home
   threat_dataPtr threat = {};
   ResetCommandPtr reset = {};
   mob_flag_data mob_flags = {}; /* Mobile information               */

--- a/src/mob_act.cpp
+++ b/src/mob_act.cpp
@@ -123,6 +123,14 @@ void mobile_activity(void)
     if (ch->fighting) // that's it for monsters busy fighting
       continue;
 
+    if (ch->mobdata->return_home_timer > 0 && --ch->mobdata->return_home_timer == 0)
+    {
+      act("$n is tired of being here and misses $s home.", ch, 0, 0, TO_ROOM, 0);
+      act("$n has decided to return home.", ch, 0, 0, TO_ROOM, 0);
+      extract_char(ch, true);
+      continue;
+    }
+
     if (!AWAKE(ch))
       continue;
     if (IS_AFFECTED(ch, AFF_PARALYSIS))


### PR DESCRIPTION
Closes #126.

When a charmed NPC's charm breaks and it's out of combat, a 10-minute timer starts; on expiry the mob announces it misses home and is extracted, so the normal zone reset repops it at its load point. Re-charming before the timer expires cancels it. This closes the exploit of stashing broken-charm mobs in safe/guild rooms.

Tested live in the Docker dev image (charm via ranger `tame`, break via `free animal`): confirmed both the return-home and the re-charm-cancel paths. Build + `testDC` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)